### PR TITLE
1. Generate pkl data from csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ I think that both implementations are hard to understand and to re-use (my point
   wget http://nlp.stanford.edu/data/glove.840B.300d.zip
   unzip glove.840B.300d.zip
   ```
-* Download the dataset in format .pkl into dataset folder: This pkl files were generated using the utilities/prepare_dataset.py script which separate the context and response from each of the train.csv, test.csv and dev.csv taht you can download from here https://github.com/rkadlec/ubuntu-ranking-dataset-creator by running ./generate.sh without any options. In case you need this raw data, just email me I can provide them upon request.
+* Download the dataset in format .pkl into dataset folder: This pkl files were generated using the utilities/prepare_dataset.py script which separate the context and response from each of the train.csv, test.csv and dev.csv taht you can download from here https://github.com/rkadlec/ubuntu-ranking-dataset-creator by running ./generate.sh without any options.
+```
+cd utilities
+python prepare_dataset_from_csv.py
+```
+In case you need this raw data, just email me I can provide them upon request.
 
   ```
   https://drive.google.com/file/d/1VjVzY0MqKj0b-q_KXnaHC49qCw3iDqEY/view?usp=sharing

--- a/utilities/prepare_dataset_from_csv.py
+++ b/utilities/prepare_dataset_from_csv.py
@@ -1,0 +1,134 @@
+# -*- encoding:utf-8 -*-
+
+"""
+here we prepare the dataset in form of .pkl files
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import numpy as np
+from keras.preprocessing.text import Tokenizer
+from keras.preprocessing.sequence import pad_sequences
+import pickle
+import pandas as pd
+np.random.seed(1337)
+#import cPickle
+
+DATA_DIR = '../dataset/'
+
+def build_train_set():
+    train = pd.read_csv(DATA_DIR + 'train.csv')
+    rows = train.shape[0]
+    context = []
+    response = []
+    label = []
+    for i in range(rows):
+        context.append(train.loc[i].Context)
+        response.append(train.loc[i].Utterance)
+        label.append(int(train.loc[i].Label))
+    return context, response, label
+
+def build_prediction_set(csv_file):
+    df = pd.read_csv(DATA_DIR + csv_file)
+    rows = df.shape[0]
+    context = []
+    response = []
+    label = []
+    for i in range(rows):
+        # add 10 contexts
+        for j in range(10):
+            context.append(df.loc[i].Context)
+        # add ground truth
+        response.append(df.loc[i]['Ground Truth Utterance'])
+        # add 9 fakse responses
+        response.append(df.loc[i].Distractor_0)
+        response.append(df.loc[i].Distractor_1)
+        response.append(df.loc[i].Distractor_2)
+        response.append(df.loc[i].Distractor_3)
+        response.append(df.loc[i].Distractor_4)
+        response.append(df.loc[i].Distractor_5)
+        response.append(df.loc[i].Distractor_6)
+        response.append(df.loc[i].Distractor_7)
+        response.append(df.loc[i].Distractor_8)
+        # add labels now 1, followed by nine 0
+        label.append(1) # ground
+        label.append(0) # 0
+        label.append(0) # 1
+        label.append(0) # 2
+        label.append(0) # 3
+        label.append(0) # 4
+        label.append(0) # 5
+        label.append(0) # 6
+        label.append(0) # 7 
+        label.append(0) # 8
+    return context, response, label
+
+def main():
+    #global MAX_SEQUENCE_LENGTH
+    #global MAX_NB_WORDS
+    #global word_index
+    # loading train data
+    train_c, train_r, train_l = build_train_set()   
+    #print(len(train_c))
+    # loading test data
+    test_c, test_r, test_l = build_prediction_set('test.csv')
+    # loading dev data
+    dev_c, dev_r, dev_l = build_prediction_set('valid.csv')
+
+    tokenizer = Tokenizer()
+    tokenizer.fit_on_texts(train_c)
+    tokenizer.fit_on_texts(train_r)
+    tokenizer.fit_on_texts(test_c)
+    tokenizer.fit_on_texts(test_r)
+    tokenizer.fit_on_texts(dev_c)
+    tokenizer.fit_on_texts(dev_r)
+
+    train_c = tokenizer.texts_to_sequences(train_c)
+    train_r = tokenizer.texts_to_sequences(train_r)
+    test_c = tokenizer.texts_to_sequences(test_c)
+    test_r = tokenizer.texts_to_sequences(test_r)
+    dev_c = tokenizer.texts_to_sequences(dev_c)
+    dev_r = tokenizer.texts_to_sequences(dev_r)
+
+    MAX_SEQUENCE_LENGTH = max([len(seq) for seq in train_c + train_r
+                                                    + test_c + test_r
+                                                    + dev_c + dev_r])
+    print(MAX_SEQUENCE_LENGTH)
+    MAX_NB_WORDS = len(tokenizer.word_index) + 1
+    word_index = tokenizer.word_index
+    MAX_SEQUENCE_LENGTH = 160
+    print("MAX_SEQUENCE_LENGTH: {}".format(MAX_SEQUENCE_LENGTH))
+    print("MAX_NB_WORDS: {}".format(MAX_NB_WORDS))
+
+    train_c = pad_sequences(train_c, maxlen=MAX_SEQUENCE_LENGTH)
+    train_r = pad_sequences(train_r, maxlen=MAX_SEQUENCE_LENGTH)
+    test_c = pad_sequences(test_c, maxlen=MAX_SEQUENCE_LENGTH)
+    test_r = pad_sequences(test_r, maxlen=MAX_SEQUENCE_LENGTH)
+    dev_c = pad_sequences(dev_c, maxlen=MAX_SEQUENCE_LENGTH)
+    dev_r = pad_sequences(dev_r, maxlen=MAX_SEQUENCE_LENGTH)
+
+    # shuffle training set
+    indices = np.arange(train_c.shape[0])
+    
+    np.random.shuffle(indices)
+
+    train_c = np.asarray(train_c)
+    train_r = np.asarray(train_r)
+    train_l = np.asarray(train_l)
+
+    train_c = train_c[indices]
+    train_r = train_r[indices]
+    train_l = train_l[indices]
+
+    pickle.dump([train_c, train_r, train_l], open(DATA_DIR + "/train.pkl", "wb"), protocol=-1)
+    pickle.dump([test_c, test_r, test_l], open(DATA_DIR + "/test.pkl", "wb"), protocol=-1)
+    pickle.dump([dev_c, dev_r, dev_l], open(DATA_DIR + "/dev.pkl", "wb"), protocol=-1)
+
+    pickle.dump([MAX_SEQUENCE_LENGTH, MAX_NB_WORDS, word_index], open(DATA_DIR + "/params.pkl", "wb"), protocol=-1)
+
+    #return train_c, train_r, train_l, test_c, test_r, test_l, dev_c, dev_r, dev_l
+    
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fix for issue 1.
I have tested the code and performance is similar to what mentioned in the paper, also recently they have changed the distribution as well ubuntu-ranking-dataset-creator.

Train on 1000000 samples, validate on 195600 samples
Epoch 1/1
 999936/1000000 [============================>.] - ETA: 0s - loss: 0.4848[[ 0.86172521]
 [ 0.30331194]
 [ 0.06095245]
 ...,
 [ 0.060091  ]
 [ 0.02661839]
 [ 0.0245102 ]]
group_size: 2
recall@1 0.894683026585
group_size: 5
recall@1 0.733333333333
recall@2 0.894120654397
group_size: 10
recall@1 0.610889570552
recall@2 0.769836400818
1000000/1000000 [==============================] - 9767s 10ms/step - loss: 0.4848 - val_loss: 0.3791

Perform on test set after Epoch: 1...!
group_size: 2
recall@1 0.890486257928
group_size: 5
recall@1 0.727589852008
recall@2 0.888794926004
group_size: 10
recall@1 0.60665961945
recall@2 0.764006342495
recall@5 0.943763213531